### PR TITLE
Edits for compatability with aws-otel-collector v13

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   otel:
     image: public.ecr.aws/aws-observability/aws-otel-collector:latest
-    command: --config /config/collector-config.yml --log-level debug
+    command: --config /config/collector-config.yml
     volumes:
       - .:/config
     environment:


### PR DESCRIPTION
# Description

With the release of `public.ecr.aws/aws-observability/aws-otel-collector:latest` `v13`, we need to update our CI workflow to be compatible with it.

Specifically we remove the `--log-level` flag to fix the CI build.