### PR TITLE
Add DEBUG Log Level to integration workflow

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -20,6 +20,9 @@ exporters:
     region: us-west-2
 
 service:
+  telemetry:
+    logs:
+      level: debug
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
# Description

Follow up to #102 which removed the `--log-level` flag, this PR adds the `debug` log level in the YAML configuration as update [in the collector PR](https://github.com/open-telemetry/opentelemetry-collector/pull/4009/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R174).