### PR TITLE
Pin GitHub Action references to commit SHAs

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -17,15 +17,15 @@ jobs:
     steps:
     # Set up building environment, patch the dev repo code on dispatch events.  
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 #v2.2.0
       with:
         go-version: '^1.17.7'
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
     
     - name: Cache go
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4.3.0
       with:
         path: |
           ~/.cache/go-build
@@ -42,16 +42,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 #v1.7.0
         
       - name: Build Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a #v2.10.0
         with:
           context: ./sampleapp
           push: false
           tags: sampleapp
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  static-code-checks:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+        with:
+          fetch-depth: 0
+      - name: Check for versioned GitHub actions
+        if: always()
+        run: |
+          # Get changed GitHub workflow/action files
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
+          
+          if [ -n "$CHANGED_FILES" ]; then
+            # Check for any versioned actions, excluding comments and this validation script
+            VIOLATIONS=$(grep -Hn "uses:.*@v" $CHANGED_FILES | grep -v "grep.*uses:.*@v" | grep -v "#.*@v" || true)
+            if [ -n "$VIOLATIONS" ]; then
+              echo "Found versioned GitHub actions. Use commit SHAs instead:"
+              echo "$VIOLATIONS"
+              exit 1
+            fi
+          fi
+          
+          echo "No versioned actions found in changed files"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,11 +20,11 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@231aa2c8a89117b126725a0e11897209b7118144 #v1.1.39
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -35,7 +35,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@231aa2c8a89117b126725a0e11897209b7118144 #v1.1.39
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -49,4 +49,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@231aa2c8a89117b126725a0e11897209b7118144 #v1.1.39

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,31 +12,31 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 #v1.7.0
 
       - name: Cache Docker layer
-        uses: actions/cache@v2
+        uses: actions/cache@2b250bc32ad02700b996b496c14ac8c2840a2991 #v2.1.8
         with:
             path: /tmp/.buildx-cache
             key: ${{ runner.os }}-buildx-${{ github.sha }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 #v1.7.0
         with:
          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
          role-duration-seconds: 1200
          aws-region: us-east-1
 
       - name: Login to ECR
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 #v1.14.1
         with:
           registry: public.ecr.aws
 
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a #v2.10.0
         with:
           context: sampleapp
           push: true

--- a/.github/workflows/pr-build-modules.yml
+++ b/.github/workflows/pr-build-modules.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - id: set-modules
         run: |
           echo "modules=$(find . -name go.mod -d -not -path "./.github/*" -not -path "./sampleapp/*" | sed -r 's|/[^/]+$||' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -30,12 +30,12 @@ jobs:
       matrix:
         modules: ${{ fromJSON(needs.detect-modules-to-lint-and-test.outputs.modules) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff #v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: golangci-lint ${{ matrix.modules }}
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 #v6.5.2
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ${{ matrix.modules }}
@@ -57,9 +57,9 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff #v5.6.0
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true

--- a/.github/workflows/release-udp-exporter.yml
+++ b/.github/workflows/release-udp-exporter.yml
@@ -23,9 +23,9 @@ jobs:
     needs: validate-udp-exporter-e2e-test
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff #v5.6.0
         with:
             go-version: "1.24.0"
             check-latest: true

--- a/.github/workflows/release-xray-remote-sampler.yml
+++ b/.github/workflows/release-xray-remote-sampler.yml
@@ -23,9 +23,9 @@ jobs:
     needs: validate-xray-remote-sampler-e2e-test
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff #v5.6.0
         with:
             go-version: "1.24.0"
             check-latest: true

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           echo "$TEST_DURATION_MINUTES" | tee --append $GITHUB_ENV;
       - name: Clone This Repo @ ${{ env.TARGET_SHA }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
         with:
           ref: ${{ env.TARGET_SHA }}
 
@@ -92,7 +92,7 @@ jobs:
     # MARK: - Run Performance Tests
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 #v1.7.0
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 21600 # 6 Hours
@@ -192,7 +192,7 @@ jobs:
           git checkout main;
           [[ $HAS_RESULTS_ALREADY == true ]]
       - name: Graph and Report Performance Test Averages result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 #v1.21.0
         continue-on-error: true
         id: check-failure-after-performance-tests
         with:
@@ -212,7 +212,7 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: soak-tests/per-commit-overall-results
       - name: Publish Issue if failed DURING Performance Tests
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 #v2.9.2
         if: ${{ github.event_name == 'schedule' &&
           steps.check-failure-during-performance-tests.outcome == 'failure' }}
         env:
@@ -223,7 +223,7 @@ jobs:
           filename: .github/auto-issue-templates/failure-during-soak_tests.md
           update_existing: true
       - name: Publish Issue if failed AFTER Performance Tests
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 #v2.9.2
         if: ${{ github.event_name == 'schedule' &&
           steps.check-failure-after-performance-tests.outcome == 'failure' }}
         env:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark the issues/pr
-        uses: actions/stale@v6
+        uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 #v6.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} #Github workflow will add a temporary token when executing the workflow
         with:

--- a/.github/workflows/udp-exporter-e2e-test.yml
+++ b/.github/workflows/udp-exporter-e2e-test.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff #v5.6.0
         with:
             go-version: "1.24.0"
             check-latest: true
 
       - name: Configure AWS credentials for Testing Tracing
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
         with:
           role-to-assume: ${{ secrets.XRAY_UDP_EXPORTER_TEST_ROLE }}
           aws-region: 'us-east-1'

--- a/.github/workflows/xray-remote-sampler-e2e-test.yml
+++ b/.github/workflows/xray-remote-sampler-e2e-test.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff #v5.6.0
         with:
             go-version: "1.24.0"
             check-latest: true
 
       - name: Configure AWS credentials for Testing Tracing
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
         with:
           role-to-assume: ${{ secrets.XRAY_UDP_EXPORTER_TEST_ROLE }} # UDP Exporter Test Role has the required X-Ray permissions
           aws-region: 'us-east-1'
@@ -44,7 +44,7 @@ jobs:
           cd .github/test-sample-apps/xray-remote-sampler-test-app
           ./xray-remote-sampler-test-app &
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
         with:
           repository: 'aws-observability/aws-otel-community'
           ref: master


### PR DESCRIPTION
## Summary

Pin all GitHub Action references to full commit SHAs instead of mutable version tags to prevent supply chain attacks. This is a security best practice recommended by [GitHub's security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Mutable version tags (e.g. `@v2`) can be moved to point to different commits, meaning a compromised upstream action could execute malicious code in our workflows. Pinning to commit SHAs ensures we always run the exact code we've reviewed.

## Changes

| Old Reference | New Reference | Hash | Version |
|--------------|---------------|------|---------|
| actions/cache@v2 | actions/cache@2b250bc32ad02700b996b496c14ac8c2840a2991 | 2b250bc32ad02700b996b496c14ac8c2840a2991 | [v2.1.8](https://github.com/actions/cache/releases/tag/v2.1.8) |
| actions/cache@v4 | actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 | 0057852bfaa89a56745cba8c7296529d2fc39830 | [v4.3.0](https://github.com/actions/cache/releases/tag/v4.3.0) |
| actions/checkout@v2 | actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 | ee0669bd1cc54295c223e0bb666b733df41de1c5 | [v2.7.0](https://github.com/actions/checkout/releases/tag/v2.7.0) |
| actions/checkout@v4 | actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 | 34e114876b0b11c390a56381ad16ebd13914f8d5 | [v4.3.1](https://github.com/actions/checkout/releases/tag/v4.3.1) |
| actions/setup-go@v2 | actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 | bfdd3570ce990073878bf10f6b2d79082de49492 | [v2.2.0](https://github.com/actions/setup-go/releases/tag/v2.2.0) |
| actions/setup-go@v5 | actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff | 40f1582b2485089dde7abd97c1529aa768e1baff | [v5.6.0](https://github.com/actions/setup-go/releases/tag/v5.6.0) |
| actions/stale@v6 | actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 | 5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 | [v6.0.1](https://github.com/actions/stale/releases/tag/v6.0.1) |
| aws-actions/configure-aws-credentials@v1 | aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 | 67fbcbb121271f7775d2e7715933280b06314838 | [v1.7.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0) |
| aws-actions/configure-aws-credentials@v4 | aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a | 7474bc4690e29a8392af63c5b98e7449536d5c3a | [v4.3.1](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.3.1) |
| benchmark-action/github-action-benchmark@v1 | benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 | a7bc2366eda11037936ea57d811a43b3418d3073 | [v1.21.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.21.0) |
| docker/build-push-action@v2 | docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a | ac9327eae2b366085ac7f6a2d02df8aa8ead720a | [v2.10.0](https://github.com/docker/build-push-action/releases/tag/v2.10.0) |
| docker/login-action@v1 | docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 | dd4fa0671be5250ee6f50aedf4cb05514abda2c7 | [v1.14.1](https://github.com/docker/login-action/releases/tag/v1.14.1) |
| docker/setup-buildx-action@v1 | docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 | f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 | [v1.7.0](https://github.com/docker/setup-buildx-action/releases/tag/v1.7.0) |
| github/codeql-action/analyze@v1 | github/codeql-action/analyze@231aa2c8a89117b126725a0e11897209b7118144 | 231aa2c8a89117b126725a0e11897209b7118144 | [v1.1.39](https://github.com/github/codeql-action/releases/tag/v1.1.39) |
| github/codeql-action/autobuild@v1 | github/codeql-action/autobuild@231aa2c8a89117b126725a0e11897209b7118144 | 231aa2c8a89117b126725a0e11897209b7118144 | [v1.1.39](https://github.com/github/codeql-action/releases/tag/v1.1.39) |
| github/codeql-action/init@v1 | github/codeql-action/init@231aa2c8a89117b126725a0e11897209b7118144 | 231aa2c8a89117b126725a0e11897209b7118144 | [v1.1.39](https://github.com/github/codeql-action/releases/tag/v1.1.39) |
| golangci/golangci-lint-action@v6 | golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 | 55c2c1448f86e01eaae002a5a3a9624417608d84 | [v6.5.2](https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.2) |
| JasonEtco/create-an-issue@v2 | JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 | 1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 | [v2.9.2](https://github.com/JasonEtco/create-an-issue/releases/tag/v2.9.2) |

## Static Code Check

Added a `static-code-checks` job to `PR-build.yml` that will fail PRs introducing mutable GitHub Action version references.
